### PR TITLE
Fix checkbox alignment

### DIFF
--- a/public/assets/feedback.css
+++ b/public/assets/feedback.css
@@ -1,3 +1,17 @@
 .slider {
     width: 100%;
 }
+
+.checkbox--container {
+    display: flex;
+    align-items: center;
+}
+
+.checkbox--box, .checkbox--label {
+    position: relative;
+    margin: 0;
+}
+
+.checkbox--box {
+    margin-right: .3rem;
+}

--- a/public/assets/feedback.css
+++ b/public/assets/feedback.css
@@ -13,5 +13,9 @@
 }
 
 .checkbox--box {
-    margin-right: .3rem;
+    margin-right: .5rem;
+}
+
+.checkbox--label {
+    user-select: none;
 }

--- a/views/checkbox_input.njk
+++ b/views/checkbox_input.njk
@@ -1,10 +1,9 @@
 {# Inputs: check_name, check_display #}
 
-{% set sep_width = '3px' %}
-{% include 'separate.njk' %}
-
-<input class="form-check-input checkbox pull-right" type="checkbox" name="{{ check_name }}" id="{{ check_name }}">
-<label for="{{ check_name }}">{{ check_display }}</label>
+<div class="checkbox--container">
+    <input class="form-check-input checkbox pull-right checkbox--box" type="checkbox" name="{{ check_name }}" id="{{ check_name }}">
+    <label for="{{ check_name }}" class="checkbox--label">{{ check_display }}</label>
+</div>
 
 {% set check_name = undefined %}
 {% set check_display = undefined %}


### PR DESCRIPTION
Changes use flexbox, but it should still work in IE, as elements fallback to use `display: inline-block`.

On mobile, the label text wraps and is vertically centred with the checkbox; if preferred, this behaviour can be changed to move the entire label below the checkbox on mobile. 

Closes #1 😝